### PR TITLE
Kf/5 link server client

### DIFF
--- a/cmd/eventual/main.go
+++ b/cmd/eventual/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bldg14/eventual/internal/event"
 	"github.com/bldg14/eventual/internal/event/stub"
+	"github.com/bldg14/eventual/internal/middleware"
 )
 
 func main() {
@@ -25,7 +26,9 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	api := mux.New()
+	api := mux.New(
+		middleware.CORS("http://localhost:3000"),
+	)
 
 	eh := mux.NewErrorHandler()
 

--- a/cmd/eventual/main.go
+++ b/cmd/eventual/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/kevinfalting/mux"
+
 	"github.com/bldg14/eventual/internal/event"
 	"github.com/bldg14/eventual/internal/event/stub"
 )
@@ -23,12 +25,16 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	mux := http.NewServeMux()
+	api := mux.New()
 
-	mux.HandleFunc("/api/v1/events", HandleGetAllEvents)
+	eh := mux.NewErrorHandler()
+
+	api.Handle("/api/v1/events", mux.Methods(
+		mux.WithGET(eh.Err(HandleGetAllEvents)),
+	))
 
 	server := http.Server{
-		Handler: mux,
+		Handler: api,
 		Addr:    ":8080",
 	}
 
@@ -50,23 +56,21 @@ func run() error {
 	return nil
 }
 
-func HandleGetAllEvents(w http.ResponseWriter, r *http.Request) {
+func HandleGetAllEvents(w http.ResponseWriter, r *http.Request) error {
 	var eventStoreStub stub.Stub
 	events, err := event.GetAll(eventStoreStub)
 	if err != nil {
-		log.Printf("HandleGetAllEvents failed to GetAll: %s\n", err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
+		return mux.Error(fmt.Errorf("HandleGetAllEvents failed to GetAll: %w", err), http.StatusInternalServerError)
 	}
 
 	result, err := json.Marshal(events)
 	if err != nil {
-		log.Printf("HandleGetAllEvents failed to Marshal: %s\n", err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
+		return mux.Error(fmt.Errorf("HandleGetAllEvents failed to Marshal: %w", err), http.StatusInternalServerError)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(result)
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/bldg14/eventual
 
 go 1.20
+
+require github.com/kevinfalting/mux v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kevinfalting/mux v0.1.0 h1:MaIw4vBERtpuieXsBDctxFXa0MH7cvenVuuxhaG1FSk=
+github.com/kevinfalting/mux v0.1.0/go.mod h1:CtyQSnYs4qrELIxoCuZMKx0Diox29jxYcBmoawzsReU=

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/kevinfalting/mux"
+)
+
+// CORS is a middleware that adds the Access-Control-Allow-Origin header to
+// responses. The allowedOrigins argument must not be empty.
+func CORS(allowedOrigins ...string) mux.Middleware {
+	if len(allowedOrigins) == 0 {
+		panic("allowedOrigins must not be empty")
+	}
+
+	origins := strings.Join(allowedOrigins, ", ")
+
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Access-Control-Allow-Origin", origins)
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -10,11 +10,18 @@ import (
 // CORS is a middleware that adds the Access-Control-Allow-Origin header to
 // responses. The allowedOrigins argument must not be empty.
 func CORS(allowedOrigins ...string) mux.Middleware {
-	if len(allowedOrigins) == 0 {
+	filteredOrigins := make([]string, 0, len(allowedOrigins))
+	for _, origin := range allowedOrigins {
+		if origin != "" {
+			filteredOrigins = append(filteredOrigins, origin)
+		}
+	}
+
+	if len(filteredOrigins) == 0 {
 		panic("allowedOrigins must not be empty")
 	}
 
-	origins := strings.Join(allowedOrigins, ", ")
+	origins := strings.Join(filteredOrigins, ", ")
 
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,86 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bldg14/eventual/internal/middleware"
+)
+
+func TestCORS(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedOrigins []string
+		expectHeader   string
+		expectPanic    bool
+	}{
+		{
+			name:           "single origin",
+			allowedOrigins: []string{"hello, test"},
+			expectHeader:   "hello, test",
+			expectPanic:    false,
+		},
+		{
+			name:           "multiple origins",
+			allowedOrigins: []string{"hello, test", "hello, test2"},
+			expectHeader:   "hello, test, hello, test2",
+			expectPanic:    false,
+		},
+		{
+			name:           "empty origin",
+			allowedOrigins: []string{"hello, test", "", "hello, test2"},
+			expectHeader:   "hello, test, hello, test2",
+			expectPanic:    false,
+		},
+		{
+			name:           "no origins",
+			allowedOrigins: []string{},
+			expectPanic:    true,
+		},
+		{
+			name:           "nil origins",
+			allowedOrigins: nil,
+			expectPanic:    true,
+		},
+		{
+			name:           "all empty origins",
+			allowedOrigins: []string{"", "", ""},
+			expectPanic:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isPanicking := true
+			defer func() {
+				r := recover()
+				if isPanicking && !test.expectPanic {
+					t.Errorf("expected no panic, got %v", r)
+				}
+			}()
+
+			mw := middleware.CORS(test.allowedOrigins...)
+
+			h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			r := http.Request{}
+
+			handler := mw(h)
+			handler.ServeHTTP(w, &r)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
+			}
+
+			if w.Header().Get("Access-Control-Allow-Origin") != test.expectHeader {
+				t.Errorf("expected %s, got %s", test.expectHeader, w.Header().Get("Access-Control-Allow-Origin"))
+			}
+
+			isPanicking = false
+		})
+	}
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "eventual",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8080",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
## Overview

We need to be able to run the client and server on separate ports and still have them talk to each other. This maintains React's hot reloading capabilities without requiring the server to be running.

Resolves #5 

## Thought Process

I initially thought this was a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) problem, and while it is, it's not necessarily a problem for purely local development. The only required change to link the two for local development is adding a [`proxy` to `package.json`](https://create-react-app.dev/docs/proxying-api-requests-in-development/).

However, since we do plan to run this in a publicly available fashion, I decided to also tackle the CORS problem, which was relatively straightforward. Preferably, we'd like to not have to prepend all fetch calls on the client with the server address. Additionally, since the stdlib doesn't have a great way to manage middleware, and I had been looking for an opportunity to test my homegrown [github.com/kevinfalting/mux](https://github.com/kevinfalting/mux) module, I swapped it in.

I then wrote a CORS middleware and applied it to the top level mux.

## Testing Steps

You can test that the proxy works by just running the client and server after adding the following snippet anywhere in the client:
```ts
(async () => {
  try {
    const res = await fetch("/api/v1/events");
    console.log(await res.json());
  } catch (e) {
    console.log("failed to fetch:", e);
  }
})();
```
1. _client_: `npm start`
2. _server_: `go run ./cmd/eventual`
3. You'll need to open the devtools console in your browser to see the output.

And then to test that the CORS is working, remove the `"proxy": "http://localhost:8080",` from the `package.json` file. You'll need to restart React after making this change. This will return some wacky error because it's no longer proxy-ing the request. You'll need to make the following change to the snippet you previously added to the client:
```ts
(async () => {
  try {
    const res = await fetch("http://localhost:8080/api/v1/events"); // here
    console.log(await res.json());
  } catch (e) {
    console.log("failed to fetch:", e);
  }
})();
```
Then you'll be getting the response successfully because of CORS.

Now, let's break it by turning off CORS. Comment the following line in `cmd/eventual/main.go`:
```go
// middleware.CORS("http://localhost:3000"),
```
and rerun the server. The request should fail and output the following error in the browser's console:
```
Access to fetch at 'http://localhost:8080/api/v1/events' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```

And that's that!

## Risks

Doing it this way means that we're not _really_ properly testing our CORS implementation, and if we change something that might violate it, without proper testing it will find it's way into production and break. The `proxy` trick is only relevant in development mode, so once we're ready to start publishing to the public, we'll have to revisit this. The assumption is that in production we'll be serving the client from the some origin as the server. A problem left for later.