### PR TITLE
Add structconf for config mgmt

### DIFF
--- a/cmd/eventual/config.go
+++ b/cmd/eventual/config.go
@@ -1,6 +1,6 @@
 package main
 
 type config struct {
-	AllowedOrigins string `conf:"default:http://localhost:3000"`
+	AllowedOrigins string `conf:"env:ALLOWED_ORIGINS,default:http://localhost:3000"`
 	Port           int    `conf:"env:PORT,default:8080"`
 }

--- a/cmd/eventual/config.go
+++ b/cmd/eventual/config.go
@@ -1,6 +1,6 @@
-package config
+package main
 
-type Config struct {
+type config struct {
 	AllowedOrigins string `conf:"default:http://localhost:3000"`
 	Port           int    `conf:"env:PORT,default:8080"`
 }

--- a/cmd/eventual/main.go
+++ b/cmd/eventual/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kevinfalting/mux"
 	"github.com/kevinfalting/structconf"
 
-	"github.com/bldg14/eventual/internal/config"
 	"github.com/bldg14/eventual/internal/event"
 	"github.com/bldg14/eventual/internal/event/stub"
 	"github.com/bldg14/eventual/internal/middleware"
@@ -29,12 +28,12 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	conf, err := structconf.New[config.Config]()
+	conf, err := structconf.New[config]()
 	if err != nil {
 		return fmt.Errorf("failed to structconf.New: %w", err)
 	}
 
-	var cfg config.Config
+	var cfg config
 	if err := conf.Parse(ctx, &cfg); err != nil {
 		return fmt.Errorf("failed to Parse config: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.20
 
 require (
 	github.com/kevinfalting/mux v0.1.0
-	github.com/kevinfalting/structconf v0.0.0-20230723125251-fe76ed83fde8
+	github.com/kevinfalting/structconf v0.0.0-20230812185445-fdd8cf0c60c4
 )

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/bldg14/eventual
 
 go 1.20
 
-require github.com/kevinfalting/mux v0.1.0
+require (
+	github.com/kevinfalting/mux v0.1.0
+	github.com/kevinfalting/structconf v0.0.0-20230723125251-fe76ed83fde8
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/kevinfalting/mux v0.1.0 h1:MaIw4vBERtpuieXsBDctxFXa0MH7cvenVuuxhaG1FSk=
 github.com/kevinfalting/mux v0.1.0/go.mod h1:CtyQSnYs4qrELIxoCuZMKx0Diox29jxYcBmoawzsReU=
+github.com/kevinfalting/structconf v0.0.0-20230723125251-fe76ed83fde8 h1:HD82NIsbpKBxGke96Pr6eSeWqEIEPRN2BNlxAty5in4=
+github.com/kevinfalting/structconf v0.0.0-20230723125251-fe76ed83fde8/go.mod h1:XFKfda9F2c3VkSEXwrKj7x3iN8Y6F1sjnkjQXxUS4iA=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/kevinfalting/mux v0.1.0 h1:MaIw4vBERtpuieXsBDctxFXa0MH7cvenVuuxhaG1FSk=
 github.com/kevinfalting/mux v0.1.0/go.mod h1:CtyQSnYs4qrELIxoCuZMKx0Diox29jxYcBmoawzsReU=
-github.com/kevinfalting/structconf v0.0.0-20230723125251-fe76ed83fde8 h1:HD82NIsbpKBxGke96Pr6eSeWqEIEPRN2BNlxAty5in4=
-github.com/kevinfalting/structconf v0.0.0-20230723125251-fe76ed83fde8/go.mod h1:XFKfda9F2c3VkSEXwrKj7x3iN8Y6F1sjnkjQXxUS4iA=
+github.com/kevinfalting/structconf v0.0.0-20230812185445-fdd8cf0c60c4 h1:CO+VypwPR+iwF/H5Xc9rZojRd7URRnq4dIDMysTNyak=
+github.com/kevinfalting/structconf v0.0.0-20230812185445-fdd8cf0c60c4/go.mod h1:XFKfda9F2c3VkSEXwrKj7x3iN8Y6F1sjnkjQXxUS4iA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,6 @@
+package config
+
+type Config struct {
+	AllowedOrigins string `conf:"default:http://localhost:3000"`
+	Port           int    `conf:"env:PORT,default:8080"`
+}


### PR DESCRIPTION
## Overview
<!-- Provide a brief overview of your changes. -->

In order to run the server in multiple environments, we need to support dynamic configuration via environment variables at the minimum.

## Related Issues / PRs
<!-- If applicable, link to any related issues or PRs. -->

Closes: #31 

## Thought Process
<!-- Describe the reasoning behind your changes. -->

I imported https://github.com/kevinfalting/structconf for configuration management. This required creating a new config package and Config type, which I annotated with the appropriate struct tags.

I chose to name the environment variable `PORT` because that's a common env var that's set in providers like fly.io, although I couldn't find anything explicit about environment variables for the port, this may just be something we have to manually set.

I've also added the `AllowedOrigins` to the config, and we'll test that again once we're actually making requests from the client.

- https://fly.io/docs/reference/runtime-environment/

## Testing Steps
<!-- Describe the steps needed to test your changes. -->

Run the server and then you can make a request:

```sh
$ curl localhost:3000/api/v1/events
```

Which you should get back a json of events.

You can override the default value by providing the environment variable:

```sh
$ PORT=4545 go run ./cmd/eventual
```

You should see that it's listening on port `4545`.

Run the curl again with the updated port, and get the same json result.

## Risks
<!-- Describe any risks involved in implementing your changes. -->

Since we're not testing the `AllowedOrigins` we may need to fix it when we begin adding the client side requests.

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes. -->

n/a
