### PR TITLE
enable auto deploy to fly.io of server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,0 +1,15 @@
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,25 @@
+ARG GO_VERSION=1.21.0
+
+FROM golang:${GO_VERSION} as builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates tzdata
+
+RUN adduser --system --group nonrootuser
+
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build --trimpath -o ./bin/eventual ./cmd/eventual
+RUN chown nonrootuser:nonrootuser ./bin/eventual
+
+FROM scratch
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder --chown=nonrootuser:nonrootuser /src/bin/eventual /bin/eventual
+
+USER nonrootuser
+EXPOSE 8080
+ENTRYPOINT ["/bin/eventual"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,18 @@
+# fly.toml app configuration file generated for eventual on 2023-08-24T19:13:07-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "eventual"
+primary_region = "dfw"
+
+[build]
+  dockerfile = "Dockerfile.server"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]


### PR DESCRIPTION
## Overview
<!-- Provide a brief overview of your changes. -->

This adds a Dockerfile for the server and a fly configuration file so that the fly GitHub action can auto deploy the server on merges to main.

## Related Issues / PRs
<!-- If applicable, link to any related issues or PRs. -->

Resolves: #32 

## Thought Process
<!-- Describe the reasoning behind your changes. -->

I was going to initially just let the fly cli generate the toml, but it was struggling to detect the Go application. I noticed that it can just be pointed at a Dockerfile, which is what it wanted to generate anyway, so I wrote a one to have only the necessities in the resulting image.

I followed the fly.io docs to add a GitHub action and here we are!

This should auto-deploy on every merge to main. I'm not concerned about merges that don't contain any changes to the server.

## Testing Steps
<!-- Describe the steps needed to test your changes. -->

You can build and run this image locally with [Docker](https://www.docker.com) installed and running.

```sh
docker build -t eventual -f Dockerfile.server .
```

Then run it:

```sh
docker run --rm -it -p 8080:8080 eventual
```

and you can make an http request against it:

```sh
curl localhost:8080/api/v1/events
```

If you have the [fly cli](https://fly.io/docs/hands-on/install-flyctl/) installed, you can just run:

```sh
fly deploy
```

The current url for what I've manually deployed, and I expect this GitHub action to overwrite: https://eventual.fly.dev/api/v1/events

## Risks
<!-- Describe any risks involved in implementing your changes. -->

Low risk, if it doesn't work, we'll dig into why and make the necessary changes.