### PR TITLE
update Dockerfile.server to use distroless image

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,25 +1,19 @@
 ARG GO_VERSION=1.21.0
 
-FROM golang:${GO_VERSION} as builder
+FROM golang:${GO_VERSION} AS builder
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates tzdata
+WORKDIR /app
+COPY go.mod go.sum /app/
+RUN go mod download
 
-RUN adduser --system --group nonrootuser
+COPY ./cmd/eventual /app/cmd/eventual
+COPY ./internal /app/internal
+RUN CGO_ENABLED=0 go build --trimpath -o /bin/eventual ./cmd/eventual
 
-WORKDIR /src
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build --trimpath -o ./bin/eventual ./cmd/eventual
-RUN chown nonrootuser:nonrootuser ./bin/eventual
+FROM gcr.io/distroless/static AS production
 
-FROM scratch
+COPY --from=builder /bin/eventual /
 
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=builder --chown=nonrootuser:nonrootuser /src/bin/eventual /bin/eventual
-
-USER nonrootuser
 EXPOSE 8080
-ENTRYPOINT ["/bin/eventual"]
+USER nonroot
+ENTRYPOINT ["/eventual"]


### PR DESCRIPTION
## Overview
<!-- Provide a brief overview of your changes. -->

Updated the image to use a distroless image instead of FROM scratch.

## Related Issues / PRs
<!-- If applicable, link to any related issues or PRs. -->

Resolves: #41 

## Thought Process
<!-- Describe the reasoning behind your changes. -->

Looking into this more, people have already done the work of creating a bare minimum image that just needs a binary placed in it to run. These are well supported and are kept up to date.

I've updated the builder stage to just build the binary, and then the distroless stage just copies it over, and set's the user to be a non-root user. No need to copy over timezone data or certs, they already exist.

I tried to take advantage of how the layers are built and caching, so I've set each command in the file to work from least likely to change, to most likely.

## Testing Steps
<!-- Describe the steps needed to test your changes. -->

```sh
docker build -t eventual-server .
docker run -it --rm eventual-server
curl localhost:8080/api/v1/events
```

or deploy to fly:

```sh
flyctl deploy --remote-only --config ./fly.server.toml
```

## Risks
<!-- Describe any risks involved in implementing your changes. -->

Low risk, this should harden the image.