### PR TITLE
Kf/43 link client server in prod

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,10 +1,13 @@
 ARG NODE_VERSION=18
+ARG BACKEND_URL="https://eventual-server.fly.dev"
 FROM node:${NODE_VERSION} as builder
 
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install --omit="dev"
 COPY . .
+
+ENV REACT_APP_BACKEND_URL=${BACKEND_URL}
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged as nginx

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -17,3 +17,4 @@ COPY --from=builder /bin/eventual /
 EXPOSE 8080
 USER nonroot
 ENTRYPOINT ["/eventual"]
+CMD [ "-env", "production" ]

--- a/cmd/eventual/config.go
+++ b/cmd/eventual/config.go
@@ -4,3 +4,19 @@ type config struct {
 	AllowedOrigins string `conf:"env:ALLOWED_ORIGINS,default:http://localhost:3000"`
 	Port           int    `conf:"env:PORT,default:8080"`
 }
+
+var productionConfig = config{
+	AllowedOrigins: "https://eventual-client.fly.dev",
+	Port:           8080,
+}
+
+func Config(env string) config {
+	switch env {
+	case "local":
+		return config{}
+	case "production":
+		return productionConfig
+	default:
+		return config{}
+	}
+}

--- a/cmd/eventual/main.go
+++ b/cmd/eventual/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -28,12 +29,15 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
+	flagEnv := flag.String("env", "local", "environment this server is running in")
+
 	conf, err := structconf.New[config]()
 	if err != nil {
 		return fmt.Errorf("failed to structconf.New: %w", err)
 	}
+	flag.Parse()
 
-	var cfg config
+	cfg := Config(*flagEnv)
 	if err := conf.Parse(ctx, &cfg); err != nil {
 		return fmt.Errorf("failed to Parse config: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bldg14/eventual
 
-go 1.20
+go 1.21
 
 require (
 	github.com/kevinfalting/mux v0.1.0

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -7,25 +7,57 @@ import (
 	"github.com/kevinfalting/mux"
 )
 
-// CORS is a middleware that adds the Access-Control-Allow-Origin header to
-// responses. The allowedOrigins argument must not be empty.
+// CORS is a middleware that adds the appropriate headers to responses. The
+// allowedOrigins argument must not be empty. Adds Access-Control-Allow-Origin
+// and Access-Control-Allow-Headers. The rest of CORS is handled by
+// github.com/kevinfalting/mux
+//
+// If a "*" is supplied in the allowed origins, it will override and allow
+// everything. You can supply as many specific origins as you'd like, but they
+// must include the full url, including the scheme. If you need a wildcarded
+// subdomain, prepend the allowed origin with "*." but do not include a scheme.
+// Schemes for wildcarded subdomains are not supported (yet).
 func CORS(allowedOrigins ...string) mux.Middleware {
-	filteredOrigins := make([]string, 0, len(allowedOrigins))
-	for _, origin := range allowedOrigins {
-		if origin != "" {
-			filteredOrigins = append(filteredOrigins, origin)
+	origins := make(map[string]bool, len(allowedOrigins))
+	for _, allowedOrigin := range allowedOrigins {
+		if allowedOrigin != "" {
+			origins[allowedOrigin] = true
 		}
 	}
 
-	if len(filteredOrigins) == 0 {
+	if len(origins) == 0 {
 		panic("allowedOrigins must not be empty")
 	}
 
-	origins := strings.Join(filteredOrigins, ", ")
+	isOriginAllowed := func(origin string) bool {
+		if _, ok := origins["*"]; ok {
+			return true
+		}
+
+		if _, ok := origins[origin]; ok {
+			return true
+		}
+
+		for allowedOrigin := range origins {
+			if !strings.HasPrefix(allowedOrigin, "*.") {
+				continue
+			}
+
+			if strings.HasSuffix(origin, allowedOrigin[1:]) {
+				return true
+			}
+		}
+
+		return false
+	}
 
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Add("Access-Control-Allow-Origin", origins)
+			origin := r.Header.Get("Origin")
+			if isOriginAllowed(origin) {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			}
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 			h.ServeHTTP(w, r)
 		})
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
-        "@types/node": "^16.18.11",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "react": "^18.2.0",
@@ -21,6 +20,9 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/node": "^18.17.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3727,9 +3729,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
-      "version": "16.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.36.tgz",
-      "integrity": "sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ=="
+      "version": "18.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.17.tgz",
+      "integrity": "sha512-cOxcXsQ2sxiwkykdJqvyFS+MLQPLvIdwh5l6gNg8qF6s+C7XSkEWOZjK+XhUZd+mYvHV/180g2cnCcIl4l06Pw=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
-    "@types/node": "^16.18.11",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "react": "^18.2.0",
@@ -41,5 +40,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/node": "^18.17.1"
   }
 }

--- a/src/http/get.ts
+++ b/src/http/get.ts
@@ -1,0 +1,27 @@
+const baseUrl = process.env.REACT_APP_BACKEND_URL || "";
+
+export const get = async (endpoint: string, queryParameters?: Record<string, string>): Promise<any> => {
+    const queryString = queryParameters ? new URLSearchParams(queryParameters).toString() : '';
+    const url = queryString ? `${baseUrl}${endpoint}?${queryString}` : `${baseUrl}${endpoint}`;
+
+    const headers = {
+        "Content-Type": "application/json",
+    };
+
+    const config: RequestInit = {
+        method: "GET",
+        headers,
+    };
+
+    let response;
+    try {
+        response = await fetch(url, config);
+        if (!response.ok) {
+            throw new Error(String(response.status));
+        }
+    } catch (error) {
+        throw new Error(`Fetching ${url} failed: ${error}`);
+    }
+
+    return response.json();
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import { get } from "./http/get";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -17,3 +18,14 @@ root.render(
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();
+
+// TODO: Remove this when wiring up the call to display the events in the ui.
+// This only makes the api request and logs it to the console.
+(async () => {
+  try {
+    let result = await get("/api/v1/events");
+    console.log(result);
+  } catch (error) {
+    console.error(error);
+  }
+})();


### PR DESCRIPTION
## Overview
<!-- Provide a brief overview of your changes. -->

This PR allows the client to make requests across domains to the server.

## Related Issues / PRs
<!-- If applicable, link to any related issues or PRs. -->

Resolves: #18, #43 

## Thought Process
<!-- Describe the reasoning behind your changes. -->

I've documented much of it in the related issues and as commit messages. Basically, the CORS policies set in the server's middleware were incorrect and were updated. A separate config for production was required, and the Dockerfiles were updated to accomodate these new configurations.

## Testing Steps
<!-- Describe the steps needed to test your changes. -->

Ensure that the client and server can communicate by running them both locally and opening up the browser console to see the events retrieved from the server.

I've already pushed both the server and client to production via flyctl, so if you open the browser console at https://eventual-client.fly.dev/ you'll see the events printed to the console from the server.

## Risks
<!-- Describe any risks involved in implementing your changes. -->

If a configuration was incorrect, CORS will block requests from being made to the server from the client.